### PR TITLE
set executableName to fix linux build

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -3,6 +3,7 @@ const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 
 module.exports = {
   packagerConfig: {
+    "executableName": "portrait-menu-bar-app",
     icon: './src/assets/appIcon/icon.icns',
     asar: true,
     // This makes sure that the app is not shown in the dock on macOS.


### PR DESCRIPTION
without executable name
```
npm run make -- --platform linux
```
fails with
```
An unhandled rejection has occurred inside Forge:
Error: could not find the Electron app binary at "~/projects/portrait-hosting-app/out/Portrait-linux-x64/portrait-menu-bar-app". You may need to re-bundle the app using Electron Packager's "executableName" option.
```
https://github.com/electron/forge/issues/709#issuecomment-1131569112